### PR TITLE
Move lerna bootstrap to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ notifications:
 
 # Build script
 script:
-  - 'npm run bootstrap && npm run build'
+  - 'lerna bootstrap --hoist && npm run build'
 
 # Auto-publish after script
 after_success:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "test": "jest --colors --coverage --silent --passWithNoTests",
     "lint": "npm run lint:js",
     "lint:js": "eslint .",
-    "bootstrap": "lerna bootstrap --hoist",
     "build": "npm run lint && npm run test && npm run validate -- -n",
     "create": "sn-package-create",
     "validate": "sn-package-validate",


### PR DESCRIPTION
Removes Lerna bootstrapping out of the `package.json` scripts, and instead call it directly from `travis.yml`.

Change made because we don't want to run `lerna bootstrap` locally as it will update the top-level `package-lock.json` file to reference package dependencies which we don't want. A developer can still run it if they really try, but this makes it harder.

Instead of bootstrapping, a developer should `npm install` within a package directory to keep the package `node_modules` isolated. A later PR will make this process simpler and more obvious.