### PR TITLE
Thrown error from child process bubbles up to parent

### DIFF
--- a/packages/util-eslint-runner/HISTORY.md
+++ b/packages/util-eslint-runner/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 0.0.3 (2019-07-10)
+	* BUG FIX: thrown errors were not captured by parent
+
 ## 0.0.2 (2018-12-10)
 	* Minor fix to README
 	* Link to repo in package.json

--- a/packages/util-eslint-runner/bin/index.js
+++ b/packages/util-eslint-runner/bin/index.js
@@ -25,7 +25,16 @@ program
 
 		globSearch.on('match', () => {
 			globSearch.abort();
-			spawn('npm', ['run', ...program.name ? [program.name] : []], {stdio: 'inherit'});
+			const childProcess = spawn('npm', ['run', ...program.name ? [program.name] : []], {stdio: 'inherit'});
+
+			// Can an error thrown by the childprocess running the command
+			childProcess.on('exit', (code, signal) => {
+				if (code) {
+					throw new Error(`childProcess exited with code ${code}`);
+				} else if (signal) {
+					throw new Error(`childProcess was killed with signal ${signal}`);
+				}
+			});
 		});
 	});
 })();

--- a/packages/util-eslint-runner/package.json
+++ b/packages/util-eslint-runner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@springernature/util-eslint-runner",
   "description": "Run ESLint only if Javascript files are found",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes a BUG with the eslint-runner where the runner spawned a new `childProcess` to run eslint but errors from there were never captured by the parent so the build on Travis was never failing. This PR now captures the error on `process.exit` and throws, thereby causing Travis to fail the build (the desired behavior)

Working behaviour demonstrated in the global toolkit - https://github.com/springernature/frontend-global-toolkit/pull/189

DO NOT MERGE THAT PR (will amend once this is merged to use new version of runner)