### PR TITLE
Add reporting to util-package-extender

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "author": "Springer Nature",
   "scripts": {
-    "test": "jest --colors --coverage --silent --passWithNoTests",
+    "test": "jest --colors --coverage --passWithNoTests",
     "lint": "npm run lint:js",
     "lint:js": "eslint .",
     "build": "npm run lint && npm run test && npm run validate -- -n",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "author": "Springer Nature",
   "scripts": {
-    "test": "jest --colors --coverage --passWithNoTests",
+    "test": "jest --colors --coverage --silent --passWithNoTests",
     "lint": "npm run lint:js",
     "lint:js": "eslint .",
     "build": "npm run lint && npm run test && npm run validate -- -n",

--- a/packages/util-package-extender/HISTORY.md
+++ b/packages/util-package-extender/HISTORY.md
@@ -1,0 +1,7 @@
+# History
+
+## 0.0.2 (2019-09-18)
+    * Include standardised logging module
+
+## 0.0.1 (2019-09-18)
+    * Initial release

--- a/packages/util-package-extender/README.md
+++ b/packages/util-package-extender/README.md
@@ -2,7 +2,7 @@
 
 [![NPM version][badge-npm]][info-npm]
 [![Node version][badge-node]][info-node]
-![LGPL 3.0 licensed][badge-license]
+![MIT License][badge-license]
 
 This helper allows you to extend one Component Package (remote) with another (local). The helper merges files from the remote package with files from the local, ignoring any files in the remote that already exist at the local level.
 

--- a/packages/util-package-extender/__tests__/unit/_utils/get-remote-file.test.js
+++ b/packages/util-package-extender/__tests__/unit/_utils/get-remote-file.test.js
@@ -7,6 +7,8 @@
 const nock = require('nock');
 const getRemoteFile = require('../../../lib/js/_utils/_get-remote-file');
 
+jest.mock('@springernature/util-cli-reporter');
+
 describe('Getting contents of a remote file from a URL', () => {
 	afterEach(() => {
 		nock.restore();

--- a/packages/util-package-extender/__tests__/unit/_utils/merge-packages.test.js
+++ b/packages/util-package-extender/__tests__/unit/_utils/merge-packages.test.js
@@ -7,6 +7,7 @@
 const mockfs = require('../../../__mocks__/fs');
 const MOCK_PACKAGES = mockfs.__fsMockFiles();
 
+jest.mock('@springernature/util-cli-reporter');
 jest.mock('../../../lib/js/_utils/_get-remote-file');
 
 const mergePackages = require('../../../lib/js/_utils/_merge-packages');

--- a/packages/util-package-extender/__tests__/unit/index.test.js
+++ b/packages/util-package-extender/__tests__/unit/index.test.js
@@ -7,6 +7,8 @@
 const mergePackages = require('../../lib/js/_utils/_merge-packages');
 const packageExtender = require('../../lib/js/index');
 
+jest.mock('@springernature/util-cli-reporter');
+
 const results = require('../../__mocks__/filesystem-results.json');
 
 // Valid config for getPackageExtensionDetails

--- a/packages/util-package-extender/lib/js/_utils/_get-remote-file.js
+++ b/packages/util-package-extender/lib/js/_utils/_get-remote-file.js
@@ -5,6 +5,7 @@
  */
 'use strict';
 
+const reporter = require('@springernature/util-cli-reporter');
 const got = require('got');
 
 // Number of times to retry request
@@ -30,9 +31,9 @@ const config = {
 	hooks: {
 		beforeRetry: [
 			(options, error, retryCount) => {
-				console.log(`fail: requesting ${options.href}`);
-				console.log(`info: ${generateErrorMessage(error)}`);
-				console.log(`info: retrying (${retryCount}/${maxRetry})`);
+				reporter.fail('request', options.href);
+				reporter.info('error', generateErrorMessage(error));
+				reporter.info('retrying', `(${retryCount}/${maxRetry})`);
 			}
 		]
 	}

--- a/packages/util-package-extender/lib/js/_utils/_merge-packages.js
+++ b/packages/util-package-extender/lib/js/_utils/_merge-packages.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const path = require('path');
+const reporter = require('@springernature/util-cli-reporter');
 const fs = require('fs-extra');
 const getRemoteFile = require('./_get-remote-file');
 
@@ -20,9 +21,9 @@ const getRemoteFile = require('./_get-remote-file');
 async function mergeLocalFile(file, sourcePath, destinationPath) {
 	try {
 		await fs.copy(sourcePath, destinationPath);
-		console.log(`info: copying '${file}' from local package`);
+		reporter.info('copying', file, 'from local package');
 	} catch (err) {
-		console.log(`fail: problem copying '${file}' from local package`);
+		reporter.fail('error', `copying ${file}`, 'from local package');
 		throw err;
 	}
 }
@@ -40,9 +41,9 @@ async function mergeRemoteFile(file, remotePackage, destinationPath) {
 		const data = await getRemoteFile(`https://cdn.jsdelivr.net/npm/${remotePackage}/${file}`);
 		await fs.ensureDir(path.dirname(destinationPath));
 		await fs.writeFile(destinationPath, data);
-		console.log(`info: merging '${file}' from '${remotePackage}'`);
+		reporter.info('merging', file, `from '${remotePackage}'`);
 	} catch (err) {
-		console.log(`fail: problem copying '${file}' from '${remotePackage}'`);
+		reporter.fail('error', `copying ${file}`, `from '${remotePackage}'`);
 		throw err;
 	}
 }
@@ -66,7 +67,7 @@ async function mergePackages(fileList, packageJsonPath, remotePackage, outputDir
 	if (extendToDirectory) {
 		// Make sure that the outputDirectory exists
 		fs.ensureDirSync(outputPath);
-		console.log(`info: extending package into folder '${path.resolve(outputDirectory)}'`);
+		reporter.info('extending package', `into '${path.resolve(outputDirectory)}'`);
 
 		// Copy local files to outputDirectory
 		mergeAllLocalFiles = fileList.local.map(file => {

--- a/packages/util-package-extender/lib/js/index.js
+++ b/packages/util-package-extender/lib/js/index.js
@@ -6,6 +6,8 @@
  */
 'use strict';
 
+const reporter = require('@springernature/util-cli-reporter');
+
 const getLocalFileList = require('./_utils/_get-local-file-list');
 const getRemoteFileList = require('./_utils/_get-remote-file-list');
 const mergePackages = require('./_utils/_merge-packages');
@@ -47,6 +49,9 @@ async function extendPackage(packageJsonPath, remotePackage, localPackage, outpu
 	const remoteFileList = await getRemoteFileList(remotePackage);
 	const localFileList = await getLocalFileList(packageJsonPath);
 	const filteredRemoteFileList = filterRemoteFileList(remoteFileList, localFileList);
+
+	reporter.title(`extend ${remotePackage} as ${localPackage}`);
+
 	await mergePackages(
 		{
 			local: localFileList,
@@ -56,7 +61,8 @@ async function extendPackage(packageJsonPath, remotePackage, localPackage, outpu
 		remotePackage,
 		outputDirectory
 	);
-	console.log(`success: ${remotePackage} extended as ${localPackage}`);
+
+	reporter.success('extended', remotePackage, `as ${localPackage}`);
 }
 
 module.exports = {

--- a/packages/util-package-extender/package.json
+++ b/packages/util-package-extender/package.json
@@ -11,6 +11,7 @@
   },
   "homepage": "https://github.com/springernature/frontend-toolkit-utilities/tree/master/packages/util-package-extender#readme",
   "dependencies": {
+    "@springernature/util-cli-reporter": "0.0.1",
     "find-up": "^4.1.0",
     "fs-extra": "^8.1.0",
     "gitignore-globs": "^0.1.1",

--- a/packages/util-package-extender/package.json
+++ b/packages/util-package-extender/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/util-package-extender",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Extends a component package by merging with the package it extends",
   "author": "Springer Nature",
   "license": "MIT",
@@ -9,9 +9,7 @@
     "type": "git",
     "url": "git+https://github.com/springernature/frontend-toolkit-utilities.git"
   },
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
+  "homepage": "https://github.com/springernature/frontend-toolkit-utilities/tree/master/packages/util-package-extender#readme",
   "dependencies": {
     "find-up": "^4.1.0",
     "fs-extra": "^8.1.0",


### PR DESCRIPTION
Add `@springernature/util-cli-reporter` for standardised reporting, so this is ready to be used in the `frontend-package-manager`