### PR TITLE
Alt search be

### DIFF
--- a/packages/util-package-finder/HISTORY.md
+++ b/packages/util-package-finder/HISTORY.md
@@ -1,6 +1,6 @@
 # History
 
-## 0.3.0 (2019-09-01)
+## 0.3.0 (2019-10-01)
     * No longer accepts "deprecated" flag
     * Uses registry.npmjs.com to get list of packages
 

--- a/packages/util-package-finder/HISTORY.md
+++ b/packages/util-package-finder/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 0.3.0 (2019-09-01)
+    * No longer accepts "deprecated" flag
+    * Uses registry.npmjs.com to get list of packages
+
 ## 0.2.0 (2019-07-03)
     * Now returns `date` field in results
 

--- a/packages/util-package-finder/README.md
+++ b/packages/util-package-finder/README.md
@@ -61,11 +61,6 @@ Type: `Boolean`<br/>
 Default: false<br/>
 Get a list of all available versions
 
-#### deprecated
-Type: `Boolean`<br/>
-Default: false<br/>
-Show deprecated packages
-
 ## Examples
 
 ```js
@@ -153,33 +148,6 @@ packageFinder({
   date: '2019-03-08T11:55:38.384Z'  }]
 */
 
-packageFinder({
-  deprecated: true,
-  filters: ['a']
-})
-  .then(response => {
-    console.log(response);
-  }).catch(err => {
-    console.error(err);
-  });
-
-/*
-[{ name: '@springernature/a-package',
-  latest: '0.1.2',
-  versions: null,
-  status: 'development',
-  description: 'a package',
-  npm: 'https://www.npmjs.com/package/%40springernature%2Fa-package',
-  date: '2019-03-08T11:55:38.384Z'  },
-{ name: '@springernature/a-deprecated-package',
-  latest: '1.0.0',
-  versions: null,
-  status: 'deprecated',
-  description: 'a deprecated package',
-  npm: 'https://www.npmjs.com/package/%40springernature%2Fa-deprecated-package',
-  date: '2019-03-08T11:55:38.384Z'  }]
-*/
-
 ```
 
 ## CLI
@@ -203,7 +171,6 @@ $ util-package-finder --help
     --scope, -s         Set the scope (default: springernature)
     --all, -a           Get all available versions
     --filters, -f       Comma seperated list of name filters
-    --deprecated, -d    Show deprecated packages
 
   Examples
     util-package-finder
@@ -212,7 +179,6 @@ $ util-package-finder --help
     util-package-finder -a
     util-package-finder -f global,local
     util-package-finder -j -a -f global,local
-    util-package-finder -d
 ```
 
 ## License

--- a/packages/util-package-finder/README.md
+++ b/packages/util-package-finder/README.md
@@ -23,7 +23,6 @@ The status of a package is evaluated by checking the latest version and assignin
 | production | `>= 1.0.0` |
 | development | `>= 0.1.0`, `< 1.0.0` |
 | experimental | `>= 0.0.1`, `< 0.1.0` |
-| deprecated | |
 
 ## Install
 

--- a/packages/util-package-finder/__mocks__/mock-package.json
+++ b/packages/util-package-finder/__mocks__/mock-package.json
@@ -3,7 +3,8 @@
     "_id": "@springernature/a-package-name",
     "versions": {
       "0.0.1": {
-        "name": "a-package-name"
+		"name": "a-package-name",
+		"scope": "springernature"
       }
     }
   },
@@ -11,10 +12,12 @@
     "_id": "@springernature/a-nother-package-name",
     "versions": {
       "0.0.2": {
-        "name": "a-nother-package-name"
+        "name": "a-nother-package-name",
+		"scope": "springernature"
       },
       "0.0.1": {
-        "name": "a-nother-package-name"
+        "name": "a-nother-package-name",
+		"scope": "springernature"
       }
     }
   },
@@ -22,13 +25,16 @@
     "_id": "@springernature/b-package-name",
     "versions": {
       "0.1.0": {
-        "name": "b-package-name"
+        "name": "b-package-name",
+		"scope": "springernature"
       },
       "0.0.2": {
-        "name": "b-package-name"
+        "name": "b-package-name",
+		"scope": "springernature"
       },
       "0.0.1": {
-        "name": "b-package-name"
+        "name": "b-package-name",
+		"scope": "springernature"
       }
     }
   },
@@ -36,16 +42,20 @@
     "_id": "@springernature/c-package-name",
     "versions": {
       "1.0.0": {
-        "name": "c-package-name"
+        "name": "c-package-name",
+		"scope": "springernature"
       },
       "0.2.0": {
-        "name": "c-package-name"
+        "name": "c-package-name",
+		"scope": "springernature"
       },
       "0.1.0": {
-        "name": "c-package-name"
+        "name": "c-package-name",
+		"scope": "springernature"
       },
       "0.0.1": {
-        "name": "c-package-name"
+        "name": "c-package-name",
+		"scope": "springernature"
       }
     }
   }

--- a/packages/util-package-finder/__mocks__/mock-package.json
+++ b/packages/util-package-finder/__mocks__/mock-package.json
@@ -3,8 +3,8 @@
     "_id": "@springernature/a-package-name",
     "versions": {
       "0.0.1": {
-		"name": "a-package-name",
-		"scope": "springernature"
+        "name": "a-package-name",
+        "scope": "springernature"
       }
     }
   },
@@ -17,7 +17,7 @@
       },
       "0.0.1": {
         "name": "a-nother-package-name",
-		"scope": "springernature"
+        "scope": "springernature"
       }
     }
   },
@@ -26,15 +26,15 @@
     "versions": {
       "0.1.0": {
         "name": "b-package-name",
-		"scope": "springernature"
+        "scope": "springernature"
       },
       "0.0.2": {
         "name": "b-package-name",
-		"scope": "springernature"
+        "scope": "springernature"
       },
       "0.0.1": {
         "name": "b-package-name",
-		"scope": "springernature"
+        "scope": "springernature"
       }
     }
   },
@@ -43,19 +43,19 @@
     "versions": {
       "1.0.0": {
         "name": "c-package-name",
-		"scope": "springernature"
+        "scope": "springernature"
       },
       "0.2.0": {
         "name": "c-package-name",
-		"scope": "springernature"
+        "scope": "springernature"
       },
       "0.1.0": {
         "name": "c-package-name",
-		"scope": "springernature"
+        "scope": "springernature"
       },
       "0.0.1": {
         "name": "c-package-name",
-		"scope": "springernature"
+        "scope": "springernature"
       }
     }
   }

--- a/packages/util-package-finder/__mocks__/mock-package.json
+++ b/packages/util-package-finder/__mocks__/mock-package.json
@@ -13,7 +13,7 @@
     "versions": {
       "0.0.2": {
         "name": "a-nother-package-name",
-		"scope": "springernature"
+        "scope": "springernature"
       },
       "0.0.1": {
         "name": "a-nother-package-name",

--- a/packages/util-package-finder/__mocks__/mock-response-versions.json
+++ b/packages/util-package-finder/__mocks__/mock-response-versions.json
@@ -1,5 +1,5 @@
 {
-  "results": [
+  "objects": [
     {
       "name": "@springernature/a-nother-package-name",
       "description": "a-nother-package-name-description",

--- a/packages/util-package-finder/__mocks__/mock-response.json
+++ b/packages/util-package-finder/__mocks__/mock-response.json
@@ -1,5 +1,5 @@
 {
-  "results": [
+  "objects": [
     {
       "name": "@springernature/a-nother-package-name",
       "description": "a-nother-package-name-description",

--- a/packages/util-package-finder/__mocks__/mock-search.json
+++ b/packages/util-package-finder/__mocks__/mock-search.json
@@ -3,6 +3,7 @@
     {
       "package": {
         "name": "@springernature/a-package-name",
+		"scope": "springernature",
         "version": "0.0.1",
         "description": "a-package-name-description",
         "links": {
@@ -14,6 +15,7 @@
     {
       "package": {
         "name": "@springernature/a-nother-package-name",
+		"scope": "springernature",
         "version": "0.0.2",
         "description": "a-nother-package-name-description",
         "links": {
@@ -25,6 +27,7 @@
     {
       "package": {
         "name": "@springernature/b-package-name",
+		"scope": "springernature",
         "version": "0.1.0",
         "description": "b-package-name-description",
         "links": {
@@ -36,6 +39,7 @@
     {
       "package": {
         "name": "@springernature/c-package-name",
+		"scope": "springernature",
         "version": "1.0.0",
         "description": "c-package-name-description",
         "links": {

--- a/packages/util-package-finder/__mocks__/mock-search.json
+++ b/packages/util-package-finder/__mocks__/mock-search.json
@@ -1,5 +1,5 @@
 {
-  "results": [
+  "objects": [
     {
       "package": {
         "name": "@springernature/a-package-name",

--- a/packages/util-package-finder/__mocks__/mock-search.json
+++ b/packages/util-package-finder/__mocks__/mock-search.json
@@ -3,7 +3,7 @@
     {
       "package": {
         "name": "@springernature/a-package-name",
-		"scope": "springernature",
+        "scope": "springernature",
         "version": "0.0.1",
         "description": "a-package-name-description",
         "links": {
@@ -15,7 +15,7 @@
     {
       "package": {
         "name": "@springernature/a-nother-package-name",
-		"scope": "springernature",
+        "scope": "springernature",
         "version": "0.0.2",
         "description": "a-nother-package-name-description",
         "links": {
@@ -27,7 +27,7 @@
     {
       "package": {
         "name": "@springernature/b-package-name",
-		"scope": "springernature",
+        "scope": "springernature",
         "version": "0.1.0",
         "description": "b-package-name-description",
         "links": {
@@ -39,7 +39,7 @@
     {
       "package": {
         "name": "@springernature/c-package-name",
-		"scope": "springernature",
+        "scope": "springernature",
         "version": "1.0.0",
         "description": "c-package-name-description",
         "links": {

--- a/packages/util-package-finder/__tests__/unit/lib/js/index.test.js
+++ b/packages/util-package-finder/__tests__/unit/lib/js/index.test.js
@@ -4,6 +4,9 @@
  */
 'use strict';
 
+// to run just these tests:
+// ./node_modules/jest/bin/jest.js --colors packages/util-package-finder/__tests__/unit/lib/js/index.test.js
+
 const fetch = require('jest-fetch-mock');
 
 jest.setMock('node-fetch', fetch);

--- a/packages/util-package-finder/__tests__/unit/lib/js/index.test.js
+++ b/packages/util-package-finder/__tests__/unit/lib/js/index.test.js
@@ -72,7 +72,7 @@ describe('Get a list of scoped packages', () => {
 		).resolves.toEqual(response.objects);
 	});
 
-	test('Get all packages when setting scope', () => {
+	test('Get all packages when setting "at"-scope', () => {
 		fetch.mockResponses(
 			[JSON.stringify(mockSearchResults), {status: 200}],
 			[JSON.stringify(mockPackageResults['a-package-name']), {status: 200}],
@@ -84,6 +84,21 @@ describe('Get a list of scoped packages', () => {
 		expect.assertions(1);
 		return expect(
 			getPackages({scope: '@springernature'})
+		).resolves.toEqual(mockResponse.objects);
+	});
+
+	test('Get all packages when setting scope', () => {
+		fetch.mockResponses(
+			[JSON.stringify(mockSearchResults), {status: 200}],
+			[JSON.stringify(mockPackageResults['a-package-name']), {status: 200}],
+			[JSON.stringify(mockPackageResults['a-nother-package-name']), {status: 200}],
+			[JSON.stringify(mockPackageResults['b-package-name']), {status: 200}],
+			[JSON.stringify(mockPackageResults['c-package-name']), {status: 200}]
+		);
+
+		expect.assertions(1);
+		return expect(
+			getPackages({scope: 'springernature'})
 		).resolves.toEqual(mockResponse.objects);
 	});
 

--- a/packages/util-package-finder/__tests__/unit/lib/js/index.test.js
+++ b/packages/util-package-finder/__tests__/unit/lib/js/index.test.js
@@ -35,13 +35,13 @@ describe('Get a list of scoped packages', () => {
 		expect.assertions(1);
 		return expect(
 			getPackages()
-		).resolves.toEqual(mockResponse.results);
+		).resolves.toEqual(mockResponse.objects);
 	});
 
 	test('Get filtered packages (single filter) in the default scope', () => {
 		let response = Object.assign({}, mockResponse);
 		const regex = new RegExp('@springernature/a-package-name|@springernature/a-nother-package-name');
-		response.results = response.results.filter(res => res.name.match(regex));
+		response.objects = response.objects.filter(res => res.name.match(regex));
 
 		fetch.mockResponses(
 			[JSON.stringify(mockSearchResults), {status: 200}],
@@ -52,13 +52,13 @@ describe('Get a list of scoped packages', () => {
 		expect.assertions(1);
 		return expect(
 			getPackages({filters: ['a']})
-		).resolves.toEqual(response.results);
+		).resolves.toEqual(response.objects);
 	});
 
 	test('Get filtered packages (multiple filters) in the default scope', () => {
 		let response = Object.assign({}, mockResponse);
 		const regex = new RegExp('@springernature/b-package-name|@springernature/c-package-name');
-		response.results = response.results.filter(res => res.name.match(regex));
+		response.objects = response.objects.filter(res => res.name.match(regex));
 
 		fetch.mockResponses(
 			[JSON.stringify(mockSearchResults), {status: 200}],
@@ -69,7 +69,7 @@ describe('Get a list of scoped packages', () => {
 		expect.assertions(1);
 		return expect(
 			getPackages({filters: ['b', 'c']})
-		).resolves.toEqual(response.results);
+		).resolves.toEqual(response.objects);
 	});
 
 	test('Get all packages when setting scope', () => {
@@ -84,7 +84,7 @@ describe('Get a list of scoped packages', () => {
 		expect.assertions(1);
 		return expect(
 			getPackages({scope: '@springernature'})
-		).resolves.toEqual(mockResponse.results);
+		).resolves.toEqual(mockResponse.objects);
 	});
 
 	test('Get all packages with versions', () => {
@@ -99,7 +99,7 @@ describe('Get a list of scoped packages', () => {
 		expect.assertions(1);
 		return expect(
 			getPackages({versions: true})
-		).resolves.toEqual(mockResponseVersions.results);
+		).resolves.toEqual(mockResponseVersions.objects);
 	});
 
 	test('Returns empty array when no results found', () => {

--- a/packages/util-package-finder/bin/index.js
+++ b/packages/util-package-finder/bin/index.js
@@ -18,7 +18,6 @@ const cli = meow(`
 		--scope, -s         Set the scope (default: springernature)
 		--all, -a           Get all available versions
 		--filters, -f       Comma seperated list of name filters
-		--deprecated, -d    Show deprecated packages
 
 	Examples
 		util-package-finder
@@ -27,7 +26,6 @@ const cli = meow(`
 		util-package-finder -a
 		util-package-finder -f global,local
 		util-package-finder -j -a -f global,local
-		util-package-finder -d
 `, {
 	booleanDefault: undefined,
 	flags: {
@@ -49,11 +47,6 @@ const cli = meow(`
 		filters: {
 			type: 'string',
 			alias: 'f'
-		},
-		deprecated: {
-			type: 'boolean',
-			alias: 'd',
-			default: false
 		}
 	}
 });
@@ -61,8 +54,7 @@ const cli = meow(`
 const params = {
 	...cli.flags.scope && {scope: cli.flags.scope},
 	...cli.flags.filters && {filters: cli.flags.filters.split(',')},
-	...cli.flags.all && {versions: cli.flags.all},
-	...cli.flags.deprecated && {deprecated: cli.flags.deprecated}
+	...cli.flags.all && {versions: cli.flags.all}
 };
 
 /**
@@ -100,9 +92,9 @@ const printCli = response => {
 	));
 
 	response.forEach(item => {
-		const status = (item.status === 'deprecated') ? chalk.red.dim(`[${item.status}]`) : chalk.dim(`[${item.status}]`);
-		const name = (item.status === 'deprecated') ? chalk.dim(item.name) : item.name;
-		const icon = (item.status === 'deprecated') ? figures.circle : figures.circleFilled;
+		const status = chalk.dim(`[${item.status}]`);
+		const name = item.name;
+		const icon = figures.circleFilled;
 
 		console.log(chalk.cyan(`${icon} ${name} ${status} ${chalk.green.bold.dim(item.latest)}`));
 

--- a/packages/util-package-finder/bin/index.js
+++ b/packages/util-package-finder/bin/index.js
@@ -94,12 +94,11 @@ const printCli = response => {
 	response.forEach(item => {
 		const status = chalk.dim(`[${item.status}]`);
 		const name = item.name;
-		const icon = figures.circleFilled;
 
-		console.log(chalk.cyan(`${icon} ${name} ${status} ${chalk.green.bold.dim(item.latest)}`));
+		console.log(chalk.cyan(` ${name} ${status} ${chalk.green.bold.dim(item.latest)}`));
 
 		if (params.versions) {
-			console.log(`  ${chalk.dim(formatVersions(item.versions))}`);
+			console.log(`${chalk.dim(formatVersions(item.versions))}`);
 		}
 	});
 };

--- a/packages/util-package-finder/lib/js/index.js
+++ b/packages/util-package-finder/lib/js/index.js
@@ -11,16 +11,21 @@ const has = require('lodash/has');
 const semver = require('semver');
 
 /**
- * API endpoint to NPM registry
- * @type {String}
+ * Use alternate backend to get all packages
+ * @type {Boolean}
  */
-const npmRegistry = 'https://registry.npmjs.org/';
+const getAllPackagesFromNPM = false;
+
+const endpoints = {
+	npmsio: 'https://api.npms.io/v2/',
+	npm: 'http://registry.npmjs.com'
+};
 
 /**
- * API endpoint to npms.io
+ * API endpoint to get all packages from
  * @type {String}
  */
-const npmsEndpoint = 'https://api.npms.io/v2/';
+const getAllPackagesEndpoint = getAllPackagesFromNPM ? endpoints.npm : endpoints.npmsio;
 
 /**
  * Get default function options
@@ -121,7 +126,7 @@ const getVersions = (json, versions) => {
 		json.results
 			.map(n => n.package.name)
 			.forEach(name => {
-				const promise = fetch(`${npmRegistry}${encodeURIComponent(name)}`)
+				const promise = fetch(`${endpoints.npm}${encodeURIComponent(name)}`)
 					.then(response => response.json())
 					.then(packageJson => {
 						json.results
@@ -188,9 +193,9 @@ const setStatus = json => {
  * @param {Boolean} d show deprecated packages
  * @return {Promise<Array>}
  */
-const getURI = (scope, d) => {
+const getAllPackagesURI = (scope, d) => {
 	const deprecated = (d) ? '' : '%20not:deprecated';
-	return `${npmsEndpoint}search?q=scope%3A${scope}${deprecated}&size=250`;
+	return `${getAllPackagesEndpoint}search?q=scope%3A${scope}${deprecated}&size=250`;
 };
 
 /**
@@ -210,7 +215,7 @@ module.exports = ({
 		versions: versions,
 		deprecated: deprecated
 	})
-		.then(opts => fetch(getURI(opts.scope, deprecated)))
+		.then(opts => fetch(getAllPackagesURI(opts.scope, deprecated)))
 		.then(response => response.json())
 		.then(json => filterResults(json, getOptions({scope: scope, filters: filters})))
 		.then(json => getVersions(json, versions))

--- a/packages/util-package-finder/lib/js/index.js
+++ b/packages/util-package-finder/lib/js/index.js
@@ -18,7 +18,10 @@ const semver = require('semver');
  */
 const filterResults = (json, opts) => {
 	return new Promise(resolve => {
+		// API returns results in an "objects" key in the top level
+		// "results" makes for clearer code
 		json.results = json.objects;
+		delete json.objects;
 		if (opts.filters.length === 0) {
 			resolve(json);
 			return;
@@ -36,7 +39,7 @@ const filterResults = (json, opts) => {
  * @param {String} version single version number
  * @return {Boolean}
  */
-const isValid = version => {
+const isValidSemver = version => {
 	return semver.valid(version);
 };
 
@@ -48,7 +51,7 @@ const isValid = version => {
  */
 const sortVersions = versions => {
 	return Object.keys(versions)
-		.filter(isValid)
+		.filter(isValidSemver)
 		.sort(semver.rcompare);
 };
 

--- a/packages/util-package-finder/lib/js/index.js
+++ b/packages/util-package-finder/lib/js/index.js
@@ -143,6 +143,19 @@ const getPackagesSearchURI = scope => {
 };
 
 /**
+ * Removes scope prefix before searching on it
+ * @private
+ * @param {Object} opts search options
+ * @param {Object} opts search options with scope prefix removed
+ */
+const normaliseScopePrefix = opts => {
+	if (opts.scope.startsWith('@')) {
+		opts.scope = opts.scope.substr(1);
+	}
+	return opts;
+};
+
+/**
  * Validate default function options
  * @private
  * @param {Object} opts search options
@@ -150,6 +163,7 @@ const getPackagesSearchURI = scope => {
  */
 const validateOptions = opts => {
 	return new Promise((resolve, reject) => {
+		const options = normaliseScopePrefix(opts);
 		if (!Array.isArray(opts.filters)) {
 			reject(new Error(`Filters parameter must be of type \`array\`, found \`${typeof opts.filters}\``));
 		}
@@ -158,7 +172,7 @@ const validateOptions = opts => {
 			reject(new Error(`Versions parameter must be of type \`boolean\`, found \`${typeof opts.versions}\``));
 		}
 
-		resolve(opts);
+		resolve(options);
 	});
 };
 

--- a/packages/util-package-finder/lib/js/index.js
+++ b/packages/util-package-finder/lib/js/index.js
@@ -132,14 +132,14 @@ const setStatus = json => {
 };
 
 /**
- * Construct the search URI
+ * Get the interpolated search URI
  * @private
  * @param {String} scope NPM scope to search under
  * @return {String}
  */
-const getAllPackagesURI = scope => {
+const getPackagesSearchURI = scope => {
 	const limit = 250;
-	return `https://registry.npmjs.com/-/v1/search?text=${scope}&size=${limit}`
+	return `https://registry.npmjs.com/-/v1/search?text=${scope}&size=${limit}`;
 };
 
 /**
@@ -177,7 +177,7 @@ module.exports = ({
 		filters: filters,
 		versions: versions
 	})
-		.then(opts => fetch(getAllPackagesURI(opts.scope)))
+		.then(opts => fetch(getPackagesSearchURI(opts.scope)))
 		.then(response => response.json())
 		.then(json => filterResults(json, {scope: scope, filters: filters}))
 		.then(json => getVersions(json, versions))

--- a/packages/util-package-finder/lib/js/index.js
+++ b/packages/util-package-finder/lib/js/index.js
@@ -193,7 +193,7 @@ module.exports = ({
 	})
 		.then(opts => fetch(getPackagesSearchURI(opts.scope)))
 		.then(response => response.json())
-		.then(json => filterResults(json, {scope: scope, filters: filters}))
+		.then(json => filterResults(json, normaliseScopePrefix({scope: scope, filters: filters})))
 		.then(json => getVersions(json, versions))
 		.then(json => setStatus(json))
 		.then(json => _.flow(

--- a/packages/util-package-finder/package.json
+++ b/packages/util-package-finder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@springernature/util-package-finder",
   "description": "Get a list of packages and available versions from within an NPM scope",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "keywords": [
     "frontend",
@@ -23,6 +23,9 @@
   "homepage": "https://github.com/springernature/frontend-toolkit-utilities/tree/master/packages/util-package-finder#readme",
   "bin": {
     "util-package-finder": "./bin/index.js"
+  },
+  "scripts": {
+    "test": "echo \"Run tests from the repository root please.\" && exit 1"
   },
   "dependencies": {
     "boxen": "^2.0.0",


### PR DESCRIPTION
This changes the backend for getting all packages to registry.npmjs.com 

As such we have removed the "deprecated" option, to add it back see [this issue](https://github.com/springernature/frontend-toolkit-utilities/issues/29)
 - annoyingly the results hang off a key called "objects" not "results"
 - moved the validation functions down to near the calling code
 - some minor refactoring
