### PR TITLE
util-cli-reporter - make reporter message optional

### DIFF
--- a/packages/util-cli-reporter/HISTORY.md
+++ b/packages/util-cli-reporter/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 1.0.0 (2019-10-09)
+	* Allow the message to be optional
+	* Major version as used in production on package manager
+
 ## 0.0.2 (2019-09-25)
     * Standardised code locations across monorepo
 

--- a/packages/util-cli-reporter/__tests__/unit/lib/js/reporter.test.js
+++ b/packages/util-cli-reporter/__tests__/unit/lib/js/reporter.test.js
@@ -90,4 +90,25 @@ describe('Reporting configuration', () => {
 		expect.assertions(1);
 		expect(consoleOutput).toEqual('fail type this is my message');
 	});
+
+	test('prints to cli from `info` method, without optional message', () => {
+		reporter.info('type');
+
+		expect.assertions(1);
+		expect(consoleOutput).toEqual('info type');
+	});
+
+	test('prints to cli from `success` method, without optional message', () => {
+		reporter.success('type');
+
+		expect.assertions(1);
+		expect(consoleOutput).toEqual('success type');
+	});
+
+	test('prints to cli from `fail` method, without optional message', () => {
+		reporter.fail('type');
+
+		expect.assertions(1);
+		expect(consoleOutput).toEqual('fail type');
+	});
 });

--- a/packages/util-cli-reporter/lib/js/reporter.js
+++ b/packages/util-cli-reporter/lib/js/reporter.js
@@ -52,7 +52,7 @@ function configureOutput(type, description, message, comment) {
 	return `
 		${colors[type](type)}
 		${colors.description(description)}
-		${colors.message(message)}
+		${(message) ? colors.message(message) : ''}
 		${(comment) ? colors.comment(comment) : ''}
 	`
 		.replace(/\n/g, ' ').trim();
@@ -65,7 +65,7 @@ function configureOutput(type, description, message, comment) {
  * @param {String} message the main message
  * @param {String} comment additional comment (optional)
  */
-report.info = (description, message, comment = null) => {
+report.info = (description, message = null, comment = null) => {
 	console.log(
 		cleanWhitespace(
 			configureOutput('info', description, message, comment)
@@ -80,7 +80,7 @@ report.info = (description, message, comment = null) => {
  * @param {String} message the main message
  * @param {String} comment additional comment (optional)
  */
-report.success = (description, message, comment = null) => {
+report.success = (description, message = null, comment = null) => {
 	console.log(
 		cleanWhitespace(
 			configureOutput('success', description, message, comment)
@@ -95,7 +95,7 @@ report.success = (description, message, comment = null) => {
  * @param {String} message the main message
  * @param {String} comment additional comment (optional)
  */
-report.fail = (description, message, comment = null) => {
+report.fail = (description, message = null, comment = null) => {
 	console.log(
 		cleanWhitespace(
 			configureOutput('fail', description, message, comment)

--- a/packages/util-cli-reporter/lib/js/reporter.js
+++ b/packages/util-cli-reporter/lib/js/reporter.js
@@ -44,8 +44,8 @@ function configureTitle(string) {
  * @private
  * @param {String} type reporting type
  * @param {String} description output description
- * @param {String} message the main message
- * @param {String} comment additional comment (optional)
+ * @param {String} [message=null] the main message
+ * @param {String} [comment=null] additional comment
  * @return {String}
  */
 function configureOutput(type, description, message, comment) {
@@ -62,8 +62,8 @@ function configureOutput(type, description, message, comment) {
  * Output to CLI
  * Type: Info
  * @param {String} description output description
- * @param {String} message the main message
- * @param {String} comment additional comment (optional)
+ * @param {String} [message=null] the main message
+ * @param {String} [comment=null] additional comment
  */
 report.info = (description, message = null, comment = null) => {
 	console.log(
@@ -77,8 +77,8 @@ report.info = (description, message = null, comment = null) => {
  * Output to CLI
  * Type: Success
  * @param {String} description output description
- * @param {String} message the main message
- * @param {String} comment additional comment (optional)
+ * @param {String} [message=null] the main message
+ * @param {String} [comment=null] additional comment
  */
 report.success = (description, message = null, comment = null) => {
 	console.log(
@@ -92,8 +92,8 @@ report.success = (description, message = null, comment = null) => {
  * Output to CLI
  * Type: Fail
  * @param {String} description output description
- * @param {String} message the main message
- * @param {String} comment additional comment (optional)
+ * @param {String} [message=null] the main message
+ * @param {String} [comment=null] additional comment
  */
 report.fail = (description, message = null, comment = null) => {
 	console.log(

--- a/packages/util-cli-reporter/package.json
+++ b/packages/util-cli-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/util-cli-reporter",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "description": "Standardised CLI Logging",
   "author": "Alex Kilgour",
   "license": "MIT",


### PR DESCRIPTION
Tiny change to the `util-cli-reporter` to make the message optional.
Means that you can do this
```
reporter.info('description');
```
Instead of
```
reporter.info('description', '');
```

Also releasing this as `v1.0.0` as this is now used in production for the `frontend-package-manager` and we want opt-in updates