### PR TITLE
util-package-renderer bug

### DIFF
--- a/packages/util-package-renderer/HISTORY.md
+++ b/packages/util-package-renderer/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 0.0.3 (2020-10-05)
+    * BUG: Switches to package dir and now switches back to cwd for better integration
+
 ## 0.0.2 (2020-10-01)
     * BUG: Incorrect use of `files` field meant nothing was published
 

--- a/packages/util-package-renderer/lib/js/render.js
+++ b/packages/util-package-renderer/lib/js/render.js
@@ -144,15 +144,18 @@ const renderDemo = async ({
 	distFolderPath
 } = {}) => {
 	// Confirm path of package to render & get package.json
+	const cwd = process.cwd();
 	const packageRootPath = path.resolve(file.sanitisePath(packageRoot));
 	const packageJSON = getPackageJson(packageRootPath);
 	const demoCodePath = path.join(packageRootPath, demoCodeFolder);
-	const distFolderPathRelative = (distFolderPath) ? path.relative(process.cwd(), distFolderPath) : undefined;
+	const distFolderPathRelative = (distFolderPath) ? path.relative(cwd, distFolderPath) : undefined;
 
 	// Set reporting level and switch to package dir
 	reporter.init(reportingLevel);
 	reporter.title(`Rendering demo of ${packageJSON.name}`);
-	reporter.info('demo code location', path.relative(process.cwd(), demoCodePath));
+	reporter.info('demo code location', path.relative(cwd, demoCodePath));
+
+	// Switch to the package path
 	process.chdir(packageRootPath);
 
 	// Install dependencies
@@ -163,11 +166,14 @@ const renderDemo = async ({
 
 	// Write html to file
 	if (distFolderPath) {
-		writeHtmlFile(distFolderPath, distFolderPathRelative, html);
+		await writeHtmlFile(distFolderPath, distFolderPathRelative, html);
+		process.chdir(cwd);
 		return;
 	}
 
+	// Switch back to original dir
 	// Return the html content
+	process.chdir(cwd);
 	return html;
 };
 

--- a/packages/util-package-renderer/package.json
+++ b/packages/util-package-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/util-package-renderer",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Renders a package that passes SN package validation",
   "author": "jpw, ajk",
   "license": "MIT",


### PR DESCRIPTION
### BUG
Switches to the package directory to run compilation and transpilation steps, but never switches back to the `cwd`. When this was run inside of the `frontend-package-manager` it didn't know that the directory had changed which broke subsequent steps.

This PR fixes that by storing the `cwd` at runtime, switching to the package directory to run the renderer, then switching back to stored `cwd` before Promise completion.