### PR TITLE
BUG: installation of multiple packages

### DIFF
--- a/packages/util-package-installer/HISTORY.md
+++ b/packages/util-package-installer/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 0.3.1 (2021-09-08)
+    * BUG: multiple dependencies were not being installed correctly
+
 ## 0.3.0 (2020-09-24)
     * FEATURE: add standard SN custom logging
 	* FEATURE: optionally pass config to npm install

--- a/packages/util-package-installer/__tests__/unit/lib/js/installer.js
+++ b/packages/util-package-installer/__tests__/unit/lib/js/installer.js
@@ -53,7 +53,7 @@ describe('util-package-installer', () => {
 			await install.dependenciesObject(mockDependencies.twoValidDependencies);
 			expect.assertions(2);
 			expect(child_process.spawn).toHaveBeenCalledWith(
-				'npm', ['install', '', 'foo@1.0.0 - 2.9999.9999 bar@>=1.0.2 <2.1.2']
+				'npm', ['install', '', 'foo@1.0.0 - 2.9999.9999', 'bar@>=1.0.2 <2.1.2']
 			);
 			expect(child_process.spawn).toHaveBeenCalledTimes(1);
 		});

--- a/packages/util-package-installer/lib/js/installer.js
+++ b/packages/util-package-installer/lib/js/installer.js
@@ -32,7 +32,8 @@ module.exports = {
 	 */
 	dependenciesObject: async (dependencies = {}, options = '') => {
 		const validDepdendencies = module.exports.getValidDepdendencies(dependencies);
-		const packageListAsStr = validDepdendencies.map(dep => dep.join('@')).join(' ');
+		const packageList = validDepdendencies.map(dep => dep.join('@'));
+		const packageListAsStr = packageList.join(' ');
 
 		console.log(`npm-install: ${packageListAsStr}`);
 
@@ -41,7 +42,8 @@ module.exports = {
 		}
 
 		const spawnPromiseResolution = await new Promise((resolve, reject) => {
-			const child = cp.spawn('npm', ['install', options, packageListAsStr]);
+			const installCommand = ['install', options];
+			const child = cp.spawn('npm', installCommand.concat(packageList));
 
 			let childStdout = '';
 			child.stdout.on('data', chunk => childStdout += chunk); // eslint-disable-line no-return-assign

--- a/packages/util-package-installer/package.json
+++ b/packages/util-package-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/util-package-installer",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Dynamically installs NPM packages",
   "main": "./lib/js/installer.js",
   "repository": {


### PR DESCRIPTION
## Issue
Bug where multiple packages were not being installed.

The code was using `child_process.spawn` to install NPM dependencies at the line `const child = cp.spawn('npm', ['install', options, packageListAsStr]);`.

This results in trying to execute `npm install --no-save package@version package@version` from the `frontend-package-manager` where the two packages are a single string represented by `packageListAsStr`

This breaks because each of the arguments in spawn needs to [represent a single item](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) and `packageListAsStr` concatenates multiple arguments together.

## Fix

The fix is simply to pass each dependency to install as a single item to the arguments array.

## Example of failure

This is the lockfile when `spawn` tries to execute the following command `npm install --no-save @springernature/global-javascript@^3.0.1 @springernature/brand-context@^9.0.3`.

```
{
  "lockfileVersion": 2,
  "requires": true,
  "packages": {
    "^3.0.1 @springernature/brand-context@^9.0.3": {},
    "node_modules/@springernature/global-javascript": {
      "resolved": "^3.0.1 @springernature/brand-context@^9.0.3",
      "link": true
    }
  }
}
```