### PR TITLE
util-package-renderer: Ignore hyperlinks

### DIFF
--- a/packages/util-package-renderer/HISTORY.md
+++ b/packages/util-package-renderer/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 2.2.0 (2021-11-26)
+    * FEATURE: ignore hyperlinks when converting images
+
 ## 2.1.1 (2021-11-25)
     * BUG: can't use devDependencies
 

--- a/packages/util-package-renderer/__mocks__/apackage/demo/index.hbs
+++ b/packages/util-package-renderer/__mocks__/apackage/demo/index.hbs
@@ -19,4 +19,5 @@
 		<img src="./img/img02.jpg" />
 	</div>
 	<button type="submit">Search</button>
+	<img src="http://placehold.it/200x200" />
 </form>

--- a/packages/util-package-renderer/lib/js/img-helper.js
+++ b/packages/util-package-renderer/lib/js/img-helper.js
@@ -7,7 +7,6 @@ const reporter = require('@springernature/util-cli-reporter');
 
 /**
  * Check for hyperlinks
- * @async
  * @private
  * @function isURL
  * @param {String} value check if this is a valid URL

--- a/packages/util-package-renderer/lib/js/img-helper.js
+++ b/packages/util-package-renderer/lib/js/img-helper.js
@@ -6,6 +6,26 @@ const imageDataURI = require('image-data-uri');
 const reporter = require('@springernature/util-cli-reporter');
 
 /**
+ * Check for hyperlinks
+ * @async
+ * @private
+ * @function isURL
+ * @param {String} value check if this is a valid URL
+ * @return {Boolean}
+ */
+function isURL(value) {
+	let url;
+
+	try {
+		url = new URL(value);
+	} catch (_) {
+		return false;
+	}
+
+	return url.protocol === 'http:' || url.protocol === 'https:';
+}
+
+/**
  * Find images in HTML and convert to data-uri
  * @async
  * @function imageToDataUri
@@ -21,10 +41,14 @@ const imageToDataUri = async (html, demoCodePath) => {
 	$('body').find('img').each(function () {
 		const el = $(this);
 		const imgSrc = el.attr('src');
-		images.push({
-			el: el,
-			src: imgSrc
-		});
+
+		// Ignore hyperlinks
+		if (!isURL(imgSrc)) {
+			images.push({
+				el: el,
+				src: imgSrc
+			});
+		}
 	});
 
 	// Convert images to data-uri

--- a/packages/util-package-renderer/package.json
+++ b/packages/util-package-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/util-package-renderer",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Renders a package that passes SN package validation",
   "author": "jpw, ajk",
   "license": "MIT",


### PR DESCRIPTION
we had an issue where one of the demo folders was using `http://placehold.it/430x36` as the image src. This cannot (and does not need to be) converted to a `data-uri`, so this change ignores hyperlinks within the image src.