### PR TITLE
The one that starts to move from Node Sass to Dart Sass

### DIFF
--- a/packages/util-sass-compiler/HISTORY.md
+++ b/packages/util-sass-compiler/HISTORY.md
@@ -1,4 +1,8 @@
 # History
 
+## 1.0.0
+    * BREAKING
+        * Updates the Sass compiler from Node Sass (Libsass) to Dart Sass.
+
 ## 0.1.0 (2020-07-15)
     * Simple SASS renderer with JSON

--- a/packages/util-sass-compiler/lib/js/render.js
+++ b/packages/util-sass-compiler/lib/js/render.js
@@ -7,7 +7,7 @@
 const util = require('util');
 
 const css2json = require('css2json');
-const sass = require('node-sass');
+const sass = require('sass');
 
 const sassRender = util.promisify(sass.render);
 

--- a/packages/util-sass-compiler/package.json
+++ b/packages/util-sass-compiler/package.json
@@ -12,6 +12,6 @@
   "homepage": "https://github.com/springernature/frontend-toolkit-utilities/tree/master/packages/util-sass-compiler#readme",
   "dependencies": {
     "css2json": "^1.1.1",
-    "node-sass": "^4.14.1"
+    "sass": "^1.44.0"
   }
 }


### PR DESCRIPTION
With the front-end toolkits moving from [Node Sass to Dart Sass](https://github.com/springernature/frontend-toolkits/pull/606). 

We need to change the compiler in the `util-sass-compiler`. This is the start of that.

I need some help with the render.js file as Dart Sass requires a different way of using `includePaths` and `outputStyle` and I can't, for the moment, work out hwo.