### PR TITLE
util-package-renderer: switch from node-sass to dart-sass

### DIFF
--- a/packages/util-package-renderer/.babelrc
+++ b/packages/util-package-renderer/.babelrc
@@ -15,5 +15,8 @@
 				"@babel/plugin-transform-runtime"
 			]
 		}
-	}
+	},
+	"ignore": [
+		"node_modules/"
+	]
 }

--- a/packages/util-package-renderer/HISTORY.md
+++ b/packages/util-package-renderer/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 3.0.0 (2022-01-11)
+    * BREAKING: update to dart-sass
+    * For node-sass continue using v2.2.2
+
 ## 2.2.2 (2022-01-06)
     * Update util-package-installer & util-dynamic-partial
 

--- a/packages/util-package-renderer/README.md
+++ b/packages/util-package-renderer/README.md
@@ -3,6 +3,8 @@
 Renders an Elements-compatible package into HTML with all resources inlined.  
 Optionally write the result to disk as `index.html`.
 
+> **NOTE**: As of `v3.0.0` this package works with `dart-sass`, for `node-sass` support please continue using `v2.2.2`
+
 ## Usage
 
 ```js

--- a/packages/util-package-renderer/lib/js/sass-helper.js
+++ b/packages/util-package-renderer/lib/js/sass-helper.js
@@ -1,12 +1,9 @@
 'use strict';
 
-const util = require('util');
 const path = require('path');
-const sass = require('node-sass');
+const sass = require('sass');
 const reporter = require('@springernature/util-cli-reporter');
 const file = require('./utils/file');
-
-const render = util.promisify(sass.render);
 
 const ERR_NO_PACKAGE_SASS_FOUND = 'no sass found for package';
 
@@ -24,7 +21,7 @@ const compileSASS = async (packageRoot, demoCodeFolder, minify) => {
 	let packageSASS = await file.getContent(sassEntryPoint);
 	let result;
 
-	reporter.info('starting node-sass', null, 'generating compiled css');
+	reporter.info('starting sass', null, 'generating compiled css');
 
 	// Lack of packageSASS should not be fatal
 	if (packageSASS instanceof Error) {
@@ -34,12 +31,11 @@ const compileSASS = async (packageRoot, demoCodeFolder, minify) => {
 
 	// Render the SASS to CSS
 	try {
-		result = await render({
-			data: packageSASS,
-			outputStyle: (minify) ? 'compressed' : 'expanded',
+		result = sass.compileString(packageSASS, {
+			style: (minify) ? 'compressed' : 'expanded',
 			indentType: 'tab',
 			indentWidth: 1,
-			includePaths: [
+			loadPaths: [
 				// so that relative @import paths in demoCodeFolder/main.scss resolve
 				path.join(packageRoot, demoCodeFolder)
 			]

--- a/packages/util-package-renderer/package.json
+++ b/packages/util-package-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/util-package-renderer",
-  "version": "2.2.2",
+  "version": "3.0.0",
   "description": "Renders a package that passes SN package validation",
   "author": "jpw, ajk",
   "license": "MIT",

--- a/packages/util-package-renderer/package.json
+++ b/packages/util-package-renderer/package.json
@@ -33,8 +33,8 @@
     "filesize": "^5.0.3",
     "handlebars": "^4.4.3",
     "image-data-uri": "^2.0.1",
-    "node-sass": "^4.14.1",
     "rollup": "^2.42.0",
-    "rollup-plugin-terser": "^7.0.2"
+    "rollup-plugin-terser": "^7.0.2",
+    "sass": "^1.47.0"
   }
 }


### PR DESCRIPTION
**BREAKING CHANGE**
Switch SASS renderer to use `dart-sass`
For `node-sass` support continue using `v2.2.2`