### PR TITLE
util-package-renderer: check for protocol relative URLs

### DIFF
--- a/packages/util-package-renderer/HISTORY.md
+++ b/packages/util-package-renderer/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 3.0.1 (2022-01-25)
+    * BUG: hyperlink check did not cater for protocol relative URLs
+
 ## 3.0.0 (2022-01-11)
     * BREAKING: update to dart-sass
     * For node-sass continue using v2.2.2

--- a/packages/util-package-renderer/__mocks__/apackage/demo/index.hbs
+++ b/packages/util-package-renderer/__mocks__/apackage/demo/index.hbs
@@ -20,4 +20,5 @@
 	</div>
 	<button type="submit">Search</button>
 	<img src="http://placehold.it/200x200" />
+	<img src="//placehold.it/400x400" />
 </form>

--- a/packages/util-package-renderer/lib/js/img-helper.js
+++ b/packages/util-package-renderer/lib/js/img-helper.js
@@ -42,7 +42,8 @@ const imageToDataUri = async (html, demoCodePath) => {
 		const imgSrc = el.attr('src');
 
 		// Ignore hyperlinks
-		if (!isURL(imgSrc)) {
+		// Including protocol relative links
+		if (!imgSrc.startsWith('//') && !isURL(imgSrc)) {
 			images.push({
 				el: el,
 				src: imgSrc

--- a/packages/util-package-renderer/package.json
+++ b/packages/util-package-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/util-package-renderer",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Renders a package that passes SN package validation",
   "author": "jpw, ajk",
   "license": "MIT",


### PR DESCRIPTION
**BUG**
When rendering to static HTML, images are converted to `data-uri` unless the image `src` is a hyperlink. The hyperlink check did not previously cater for protocol relative URLs of the form `//cdn.springernature.com/image.png`.
This PR fixes that bug.